### PR TITLE
project: add quarto yaml config to enable `quarto render` without an argument for users who use git repo clone

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,8 +108,8 @@ jobs:
     env:
       PDF_FILENAME: "thesis.pdf"
     steps:
-      - use: quarto-dev/quarto-actions/setup@v2
-      - use: actions/checkout@v6
+      - uses: quarto-dev/quarto-actions/setup@v2
+      - uses: actions/checkout@v6
       - run: pip install -r requirements.txt
       - run: quarto render
       - run: test -f $PDF_FILENAME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,7 @@ jobs:
       PDF_FILENAME: "thesis.pdf"
     steps:
       - uses: quarto-dev/quarto-actions/setup@v2
+      - run: quarto install tinytex --no-prompt --update-path
       - uses: actions/checkout@v6
       - name: Install LaTeX and rsvg (Linux)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
           path: example-${{ matrix.os }}.pdf
 
       - name: Upload a GIF version for inclusion in README
-        if: runner.os == 'Linux' && matrix.command == "quarto render thesis.ipynb" # TODO: This should be rewfactored to be done in a separate job
+        if: runner.os == 'Linux' && matrix.command == 'quarto render thesis.ipynb' # TODO: This should be rewfactored to be done in a separate job
         run: |
           sudo apt-get install imagemagick
           convert -density 100 example-${{ matrix.os }}.pdf -quality 100 -background white -alpha remove -alpha off frame-%03d.png

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,10 @@ jobs:
     steps:
       - uses: quarto-dev/quarto-actions/setup@v2
       - uses: actions/checkout@v6
+      - name: Install LaTeX and rsvg (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y librsvg2-bin
       - run: pip install -r requirements.txt
       - run: quarto render
       - run: test -f $PDF_FILENAME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,3 +103,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: /github/home/thesis.*
 
+  check-quarto-no-args:
+    runs-on: ubuntu-latest
+    env:
+      PDF_FILENAME: "thesis.pdf"
+    steps:
+      - use: quarto-dev/quarto-actions/setup@v2
+      - use: actions/checkout@v6
+      - run: pip install -r requirements.txt
+      - run: quarto render
+      - run: test -f $PDF_FILENAME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        command: ["quarto render thesis.ipynb", "quarto render"]
 
     steps:
       - name: Checkout repo
@@ -74,9 +75,10 @@ jobs:
           quarto use template .. --no-prompt
 
       - name: Render example notebook to PDF
+        working-directory: test-project
         run: |
           echo $QUARTO_PYTHON
-          quarto render test-project/thesis.ipynb 
+          ${{ matrix.command }}
 
       - name: Rename PDF (platform-specific)
         run: | 
@@ -89,7 +91,7 @@ jobs:
           path: example-${{ matrix.os }}.pdf
 
       - name: Upload a GIF version for inclusion in README
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.command == "quarto render thesis.ipynb" # TODO: This should be rewfactored to be done in a separate job
         run: |
           sudo apt-get install imagemagick
           convert -density 100 example-${{ matrix.os }}.pdf -quality 100 -background white -alpha remove -alpha off frame-%03d.png
@@ -103,19 +105,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: /github/home/thesis.*
-
-  check-quarto-no-args:
-    runs-on: ubuntu-latest
-    env:
-      PDF_FILENAME: "thesis.pdf"
-    steps:
-      - uses: quarto-dev/quarto-actions/setup@v2
-      - run: quarto install tinytex --no-prompt --update-path
-      - uses: actions/checkout@v6
-      - name: Install LaTeX and rsvg (Linux)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y librsvg2-bin
-      - run: pip install -r requirements.txt
-      - run: quarto render
-      - run: test -f $PDF_FILENAME

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This template aims to (by design!):
 
 To start a new project, execute `quarto use template habemus-python/quarto-reproducible-thesis`.
 
-To render it to a pdf, do: `quarto render thesis.ipynb`.
+To render it to a pdf, do: `quarto render` (or `quarto render thesis.ipynb`).
 
 With the [default notebook unchanged](https://github.com/habemus-python/quarto-reproducible-thesis/blob/main/thesis.ipynb), 
   the [resultant pdf](https://github.com/habemus-python/quarto-reproducible-thesis/releases/download/tip/thesis.pdf) looks like this (generated on CI):

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  title: "Handbook of Automation for BEng & Master's projects"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,2 +1,2 @@
 project:
-  title: "Handbook of Automation for BEng & Master's projects"
+  title: "" # the title is defined in thesis.ipynb


### PR DESCRIPTION
This enables users to do `quarto render` (without specyfing input file) see: https://quarto.org/docs/projects/quarto-projects.html#project-metadata