### PR TITLE
gitignore: add quarto render outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.quarto/
+**/*.quarto_ipynb
+**/thesis.pdf
+logo_AGH.pdf
+**/refs.bib


### PR DESCRIPTION
generally running quarto render command (as we did during labs) produces some output files which we don't want to accidently add to git