### PR TITLE
gitignore: ignore Bitmap_VS_SVG.svg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/thesis.pdf
 logo_AGH.pdf
 **/refs.bib
+Bitmap_VS_SVG.svg


### PR DESCRIPTION
as mentioned in https://github.com/habemus-python/quarto-reproducible-thesis/pull/98#discussion_r3402400502, https://github.com/habemus-python/quarto-reproducible-thesis/pull/97#discussion_r3404280222 This image is often added in our PRs. I think that, as it is autodownlaoded it should be ignored by git entirely